### PR TITLE
Fix visibility of second level menus

### DIFF
--- a/assets/js/base.js
+++ b/assets/js/base.js
@@ -31,7 +31,10 @@ jQuery(document).ready(function($)
 			animation: {opacity:'show', height:'show'},
 			speed: 'fast',
 			autoArrows: false,
-			dropShadows: false
+			dropShadows: false,
+			onShow: function() {
+				$(this).css('overflow','visible');
+			}
 		});
 	}
 


### PR DESCRIPTION
Workaround for issue #121. Wonky styling in IE8 is not addressed but (in my opinion) the submenus look too padded in all browsers so this should probably be looked at separately.
