### PR TITLE
fix array_merge error when installed in standalone WP

### DIFF
--- a/engine/includes/buddypress-cbox.php
+++ b/engine/includes/buddypress-cbox.php
@@ -64,6 +64,11 @@ add_action( 'get_header', 'cbox_theme_magic_menus' );
  */
 function cbox_theme_register_widgets()
 {
+	// bail if blogs not active
+	if ( ! bp_is_active( 'blogs' ) ) {
+		return;
+	}
+	
 	// load requirements
 	require_once 'buddypress/bp-widgets.php';
 

--- a/engine/includes/buddypress/bp-widgets.php
+++ b/engine/includes/buddypress/bp-widgets.php
@@ -2,9 +2,6 @@
 
 class CBox_BP_Blogs_Recent_Posts_Widget extends WP_Widget {
 	function __construct() {
-		if ( ! bp_is_active( 'blogs' ) ) {
-			return;
-		}
 		parent::WP_Widget( false, $name = __( 'Recent Networkwide Blog Posts', 'cbox-theme' ) );
 	}
 


### PR DESCRIPTION
Replaces https://github.com/cuny-academic-commons/cbox-theme/pull/204 the PR I accidentally added other commits to, which I'll close.

> Single site usage throws array_merge warning in `wp_register_widget_control()`. This PR avoids loading and registering `CBox_BP_Blogs_Recent_Posts_Widget` when not in WordPress multisite.
