### PR TITLE
fix joyride z-index when content has background overlay

### DIFF
--- a/engine/extensions/features/scripts/joyride/assets/joyride.css
+++ b/engine/extensions/features/scripts/joyride/assets/joyride.css
@@ -13,7 +13,7 @@ body {
   padding: 10px 10px 10px 15px;
   color: #fff;
   width: 300px;
-  z-index: 10;
+  z-index: 1000;
   font-family: "HelveticaNeue", "Helvetica Neue", "Helvetica", Helvetica, Arial, Lucida, sans-serif;
   font-weight: normal;
      -moz-border-radius: 4px;


### PR DESCRIPTION
Fix for the issue raised in https://github.com/cuny-academic-commons/cbox-theme/issues/210
