### PR TITLE
Default logo does not display in Chrome 36+

### DIFF
--- a/assets/css/cbox.css
+++ b/assets/css/cbox.css
@@ -45,7 +45,7 @@ h1#site-title,div#site-title {
     font-size: 14px;
     line-height: 180%;
 }
-#infinity-base .icext-feature a img {
+.icext-header-logo img {
 	max-width: none;
 }
 #infinity-base .icext-feature a {


### PR DESCRIPTION
I'm not sure what's happened recently to cause this, but a clean install of CBOX no longer shows the default logo in Chrome.

It seems to be caused by a mixture of declarations that work against one another: the absolutely-positioned `<h1>` has no width, the anchor nested within it inherits this (again with no width) and therefore the logo `<img>` inside the anchor does not show because it too has no width or height as a result of the default `img` declaration:

``` css
max-width: 100%;
height: auto;
```

This PR removes the default `max-width` only for logo images. This may cause some installs to behave strangely if they have very wide logo images. However, at the moment, I can't think of another way to get Chrome to display the logo without doing this.
