### PR TITLE
Prevent JS error on reinitialising dialog

### DIFF
--- a/engine/ICE/ext/options/upload/template.js
+++ b/engine/ICE/ext/options/upload/template.js
@@ -219,7 +219,7 @@
 				$.extend( true, settings, options );
 
 				// kill existing mu dialog
-				if ( _muDialog ) {
+				if ( _muDialog && $('div.icextOptionUploadWin').hasClass('ui-dialog-content') ) {
 					_muDialog.dialog('destroy').remove();
 				}
 


### PR DESCRIPTION
This PR isolates the fix referenced in [this commit by @r-a-y](https://github.com/cuny-academic-commons/cbox-theme/commit/3cee34ab386a57f4b5d991b339f1e9040da4e523) which prevents a JS error when reinitialising the Media Upload dialog.
