### PR TITLE
Reapply styles to Groupblog nav item

### DIFF
--- a/assets/css/icons.css
+++ b/assets/css/icons.css
@@ -267,9 +267,9 @@ li#nav-notifications-groups-li a:before {
 #request-membership-groups-li a:before {
     content: "y"
 }
-li#group-blog-groups-li a:before { 
-	content: "C"; 
-} 
+li#nav-group-blog-groups-li a:before {
+	content: "C";
+}
 
 /* Profile Icons  */
 #user-activity:before {


### PR DESCRIPTION
As a follow-up to [deduping BP Groupblog's nav item IDs](https://github.com/boonebgorges/bp-groupblog/pull/39), this reapplies the IconSweets icon to the "Blog" nav item in the group nav menu.