### PR TITLE
Prevent JS error after joyride completion

### DIFF
--- a/engine/extensions/features/scripts/joyride/assets/jquery.joyride.js
+++ b/engine/extensions/features/scripts/joyride/assets/jquery.joyride.js
@@ -222,16 +222,18 @@
           currentParentHeight = $('#' + parentElementID).outerHeight(),
           currentTipHeight = $('#joyRidePopup' + prevCount).outerHeight(),
           nubHeight = Math.ceil($('.joyride-nub').outerHeight() / 2);
-          if (settings.tipLocation == "bottom") {
-            $('#joyRidePopup' + prevCount).offset({top: (currentTipPosition.top + currentParentHeight + nubHeight),
-              left: currentTipPosition.left});
-          } else if (settings.tipLocation == "top") {
-            if (currentTipPosition.top <= currentTipHeight) {
-              $('#joyRidePopup' + prevCount).offset({top: (currentTipPosition.top + nubHeight + currentParentHeight),
+          if ( $('#joyRidePopup' + prevCount).length !== 0 ) {
+            if (settings.tipLocation == "bottom") {
+              $('#joyRidePopup' + prevCount).offset({top: (currentTipPosition.top + currentParentHeight + nubHeight),
                 left: currentTipPosition.left});
-            } else {
-              $('#joyRidePopup' + prevCount).offset({top: ((currentTipPosition.top) - (currentTipHeight  + nubHeight)),
-                left: currentTipPosition.left});
+            } else if (settings.tipLocation == "top") {
+              if (currentTipPosition.top <= currentTipHeight) {
+                $('#joyRidePopup' + prevCount).offset({top: (currentTipPosition.top + nubHeight + currentParentHeight),
+                  left: currentTipPosition.left});
+              } else {
+                $('#joyRidePopup' + prevCount).offset({top: ((currentTipPosition.top) - (currentTipHeight  + nubHeight)),
+                  left: currentTipPosition.left});
+              }
             }
           }
         });


### PR DESCRIPTION
The cbox theme uses a rather old version of jQuery Joyride, but upgrading to the latest would be a fair bit of effort. This PR solves an issue where, after joyride completion, a DOM element `$('#joyRidePopup' + prevCount)` cannot be found, thus throwing a JS error. For some, this means that the Activity filter links in the sidebar no longer work because they are AJAX-driven.