### PR TITLE
Update register.php for compatibility with Custom Profile Fields plugin

### DIFF
--- a/members/single/profile/edit.php
+++ b/members/single/profile/edit.php
@@ -29,6 +29,13 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 					<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>/>
 
 				<?php endif; ?>
+				
+				<?php if ( 'url' == bp_get_the_profile_field_type() ) : ?>
+
+					<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+					<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" <?php if ( bp_get_the_profile_field_is_required() ) : ?>aria-required="true"<?php endif; ?>/>
+
+				<?php endif; ?>
 
 				<?php if ( 'textarea' == bp_get_the_profile_field_type() ) : ?>
 

--- a/registration/register.php
+++ b/registration/register.php
@@ -80,6 +80,14 @@
 									<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" />
 
 								<?php endif; ?>
+								
+								<?php if ( 'url' == bp_get_the_profile_field_type() ) : ?>
+
+									<label for="<?php bp_the_profile_field_input_name(); ?>"><?php bp_the_profile_field_name(); ?> <?php if ( bp_get_the_profile_field_is_required() ) : ?><?php _e( '(required)', 'buddypress' ); ?><?php endif; ?></label>
+									<?php do_action( bp_get_the_profile_field_errors_action() ); ?>
+									<input type="text" name="<?php bp_the_profile_field_input_name(); ?>" id="<?php bp_the_profile_field_input_name(); ?>" value="<?php bp_the_profile_field_edit_value(); ?>" />
+
+								<?php endif; ?>
 
 								<?php if ( 'textarea' == bp_get_the_profile_field_type() ) : ?>
 


### PR DESCRIPTION
Fixes a compatibility issue with Custom Profile Fields plugin whereby the CBOX theme doesn't generate input fields on the public registration form for custom profile fields of type URL (field_type_url).