### PR TITLE
Pick up translation strings

### DIFF
--- a/registration/activate.php
+++ b/registration/activate.php
@@ -22,7 +22,7 @@
 				<?php if ( isset( $_GET['e'] ) ) : ?>
 					<p><?php _e( 'Your account was activated successfully! Your account details have been sent to you in a separate email.', 'buddypress' ); ?></p>
 				<?php else : ?>
-					<p><?php _e( 'Your account was activated successfully! You can now log in with the username and password you provided when you signed up.', 'buddypress' ); ?></p>
+					<p><?php printf( __( 'Your account was activated successfully! You can now <a href="%s">log in</a> with the username and password you provided when you signed up.', 'buddypress' ), wp_login_url( bp_get_root_domain() ) ); ?></p>
 				<?php endif; ?>
 
 			<?php else : ?>
@@ -35,7 +35,7 @@
 					<input type="text" name="key" id="key" value="" />
 
 					<p class="submit">
-						<input type="submit" name="submit" value="<?php _e( 'Activate', 'buddypress' ); ?>" />
+						<input type="submit" name="submit" value="<?php esc_attr_e( 'Activate', 'buddypress' ); ?>" />
 					</p>
 
 				</form>

--- a/registration/register.php
+++ b/registration/register.php
@@ -24,7 +24,7 @@
 
 				<?php do_action( 'template_notices' ); ?>
 
-				<p><?php _e( 'Registering for this site is easy, just fill in the fields below and we\'ll get a new account set up for you in no time.', 'buddypress' ); ?></p>
+				<p><?php _e( 'Registering for this site is easy. Just fill in the fields below, and we\'ll get a new account set up for you in no time.', 'buddypress' ); ?></p>
 
 				<?php do_action( 'bp_before_account_details_fields' ); ?>
 


### PR DESCRIPTION
Minor tweak so that translation strings on the Registration and Activation pages are picked up in the current CBOX version of BuddyPress.