### PR TITLE
removed conditional statements as per issue #213

### DIFF
--- a/members/single/profile/edit.php
+++ b/members/single/profile/edit.php
@@ -9,13 +9,11 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 
 		<h4><?php printf( __( "Editing '%s' Profile Group", "buddypress" ), bp_get_the_profile_group_name() ); ?></h4>
 
-		<?php if ( cbox_profile_has_multiple_tabs() ) : ?>
 			<ul class="button-nav">
 
 				<?php bp_profile_group_tabs(); ?>
 
 			</ul>
-		<?php endif; ?>
 
 		<div class="clear"></div>
 


### PR DESCRIPTION
While troubleshooting this issue I found the following forum threads in the Commons in a Box support group:
http://commonsinabox.org/groups/help-support/forum/topic/adding-profile-edit/ http://commonsinabox.org/groups/help-support/forum/topic/missing-profile-groups/

which in turn led me to issue #213.

This issue still exists in the most recent (1.0.13) so I thought I would create a "bigger blip on the radar screen" with a PR.

Thanks to @HardeepAsrani for providing the solution.