### PR TITLE
Fix display of comments and prevent warning

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -52,7 +52,8 @@ if ( post_password_required() ) { ?><p class="nocomments"><?php _e('This post is
 		<div class="nav-next fr"><?php next_comments_link( __( 'Newer Comments <span class="meta-nav">&rarr;</span>', infinity_text_domain ) ); ?></div>
 		<div class="fix"></div><!--/.fix-->
 	</div><!-- .navigation -->
-<?php } // End IF Statement
+	<?php } // End pagination IF Statement
+  } // End comment IF Statement
 
 if ( ! empty($comments_by_type['pings']) ) { ?>
  	<h3 id="comments-title"><?php  _e('Trackbacks/Pingbacks', infinity_text_domain); ?></h3>
@@ -67,14 +68,12 @@ if ( ! empty($comments_by_type['pings']) ) { ?>
 			wp_list_comments( array( 'callback' => 'list_pings', 'type' => 'pings' ) );
 		?>
 	</ol>
-<?php }
-
-	} // End have_comments() IF Statement
+<?php } // End pings IF Statement
  
  } else {
 
  
- } // End IF Statement
+ } // End have_comments() IF Statement
  
 ?>
 </div><!--/#comments-->

--- a/comments.php
+++ b/comments.php
@@ -21,7 +21,7 @@ if ( post_password_required() ) { ?><p class="nocomments"><?php _e('This post is
  * This is where our comments display is generated.
  */
  
- $comments_by_type = &separate_comments( $comments );
+ $comments_by_type = separate_comments( $comments );
  
  // You can start editing here -- including this comment!
  


### PR DESCRIPTION
I noticed that when there are only trackbacks and/or pingbacks on a post, they were not displaying because the conditionals in 'comments.php' were incorrectly nested.

I've also removed the 'return-by-reference' for `$comments_by_type` as it is throwing PHP Strict Standards warnings and seems to be unnecessary.