### PR TITLE
Replace deprecated ereg() with preg()

### DIFF
--- a/engine/includes/comments.php
+++ b/engine/includes/comments.php
@@ -83,10 +83,10 @@ if ( !function_exists( 'the_commenter_link' ) ) {
 	{
 		$commenter = get_comment_author_link();
 		
-		if ( ereg( ']* class=[^>]+>', $commenter ) ) {
-			$commenter = ereg_replace( '(]* class=[\'"]?)', '\\1url ' , $commenter );
+		if ( preg_match( '~]* class=[^>]+>~', $commenter ) ) {
+			$commenter = preg_replace( '~(]* class=[\'"]?)~', '\\1url ' , $commenter );
 		} else {
-			$commenter = ereg_replace( '(<a )/', '\\1class="url "' , $commenter );
+			$commenter = preg_replace( '~(\<a )~', '\\1class="url "' , $commenter );
 		}
 
 		print $commenter ;


### PR DESCRIPTION
The function `the_commenter_link()` uses a deprecated `ereg()` method for manipulating the comment author link. This PR replaces `ereg()` with `preg()` to prevent deprecated notices.