### PR TITLE
Fix undefined variable warning

### DIFF
--- a/engine/includes/base.php
+++ b/engine/includes/base.php
@@ -353,7 +353,7 @@ function infinity_base_cleaner_caption( $output, $attr, $content )
 	$content = apply_filters( 'infinity_base_cleaner_caption_content', $content );
 
 	// Set up the attributes for the caption <div>.
-	$attributes .= ' class="figure ' . esc_attr( $attr['align'] ) . '" style="width:'. esc_attr( $attr['width'] ) . 'px"';
+	$attributes = ' class="figure ' . esc_attr( $attr['align'] ) . '" style="width:'. esc_attr( $attr['width'] ) . 'px"';
 
 	// Open the caption <div>
 	$output = '<figure' . $attributes .'>';


### PR DESCRIPTION
Minor amend that fixes the warning shown when `$attributes` is first defined.