### PR TITLE
Remove reference to non-existent texture file

### DIFF
--- a/dashboard/assets/css/cpanel_custom.css
+++ b/dashboard/assets/css/cpanel_custom.css
@@ -80,7 +80,7 @@ div.icext-option.icext-colorpicker_launcher {
 #infinity-sidebar {
     padding: 10px;
     padding-left: 20px;
-    background: url("../images/texture.png") #FFF;
+    background: #FFF;
     border-left: 1px solid #DDDDDD;
 }
 .infinity-content { padding-right: 20px }


### PR DESCRIPTION
Related to #245 in that it's an issue with the CBOX Theme Options. The stylesheet references a missing image called 'texture.png' which doesn't exist in the 'dashboard' directory. If this image cannot be found, then the reference can be removed with this PR.