### PR TITLE
Duplicate tabs created when clicking on toolbar button multiple times in Theme Options page

### DIFF
--- a/engine/ICE/assets/js/juicy/jquery.juicy.browsertabs.js
+++ b/engine/ICE/assets/js/juicy/jquery.juicy.browsertabs.js
@@ -247,6 +247,24 @@ $.widget( 'juicy.browsertabs', $.ui.tabs, {
 		}
 	},
 
+	getTabIndex: function( target )
+	{
+		var index = null;
+
+		// Try and find our target against the existing tabs.
+		this.anchors.each( function( i, e ) {
+			item = $( 'li[aria-labelledby=' + $( e ).attr( 'id' ) + ']' );
+
+			// Found it!
+			if ( item.length && target === item.attr( 'aria-controls' ) ) {
+				index = i;
+				return false;
+			}
+		} );
+
+		return index;
+	},
+
 	loadTab: function ( anchor, selected )
 	{
 		var o = this.options,
@@ -260,7 +278,7 @@ $.widget( 'juicy.browsertabs', $.ui.tabs, {
 		}
 		
 		if ( target ) {
-			index = this._getIndex( target );
+			index = this.getTabIndex( target );
 		} else {
 			index = this.options.selected;
 		}
@@ -412,16 +430,24 @@ $.widget( 'juicy.browsertabs', $.ui.tabs, {
 
 	add: function( url, label, index )
 	{
-		$.ui.tabs.prototype.add.apply( this, arguments );
+		var self = this,
+			o = this.options,
+			anchor, panel, exists;
+
+		exists = this.getTabIndex( url.replace( '#', '') );
+
+		if ( null !== exists ) {
+			return this;
+		} else {
+			$.ui.tabs.prototype.add.apply( this, arguments );
+		}
 
 		if ( index === undefined ) {
 			index = this.anchors.length - 1;
 		}
 
-		var self = this,
-			o = this.options,
-			anchor = $( this.anchors[index] ),
-			panel = $( this.panels[index] );
+		anchor = $( this.anchors[index] );
+		panel = $( this.panels[index] );
 
 		// bind close tab click
 		if ( o.closeable == true ) {

--- a/engine/ICE/assets/js/juicy/jquery.juicy.browsertabs.js
+++ b/engine/ICE/assets/js/juicy/jquery.juicy.browsertabs.js
@@ -287,7 +287,7 @@ $.widget( 'juicy.browsertabs', $.ui.tabs, {
 			// panel exists
 			this.select( index );
 			this.url( index, href );
-			this.load( index );
+
 		} else {
 			// the title
 			var title = o.availableTabs[ this._getTabKey( target ) ];

--- a/engine/ICE/loader.php
+++ b/engine/ICE/loader.php
@@ -21,7 +21,7 @@ if ( defined( 'ICE_VERSION' ) ) {
 /**
  * ICE API: version
  */
-define( 'ICE_VERSION', '1.0' );
+define( 'ICE_VERSION', '1.0-20190823' );
 /**
  * ICE API: root directory
  */


### PR DESCRIPTION
Reported internally.

When on the CBOX Theme Options page, if you click on a toolbar button multiple times (Start, Options, User Docs, Dev Docs), duplicate tabs are created in the main horizontal navigation of the page.

To fix this, I had to alter the `jquery.juicy.browsertabs` JS in a few places:
- loadTab() method requires looking up the correct tab index so it would find the existing tab
- add() method requires checking to see if the tab already exists

It appears that the `_getIndex()` method returns the incorrect tab index, so I created a new method, `getTabIndex()`, to do this.  Could this be more elegant?  Yes, but I'm not too familiar with the JS.

I believe `jquery.juicy` was created for CBOX Theme, since I couldn't find anything online about it.  I could be wrong though.  If we don't want to patch up `juicy.browsertabs`, we could also copy the changes over to `dashboard/assets/js/cpanel.js` since that file extends `juicy.browsertabs`, but that would require duplicating the methods I mention above.

I also removed a line where the JS was trying to load the same AJAX hook again after clicking on a toolbar button.  See commit 8577149.

Tested in Chrome, Firefox and Edge.
