### PR TITLE
Replace unsupported curly braces for array keys

### DIFF
--- a/engine/ICE/lib/lessphp/less.inc.php
+++ b/engine/ICE/lib/lessphp/less.inc.php
@@ -280,7 +280,7 @@ class lessc {
 
 			$hidden = true;
 			if (!isset($block->args)) foreach ($block->tags as $tag) {
-				if ($tag{0} != $this->mPrefix) {
+				if ($tag[0] != $this->mPrefix) {
 					$hidden = false;
 					break;
 				}
@@ -315,7 +315,7 @@ class lessc {
 	function fixTags($tags) {
 		// move @ tags out of variable namespace
 		foreach ($tags as &$tag) {
-			if ($tag{0} == $this->vPrefix) $tag[0] = $this->mPrefix;
+			if ($tag[0] == $this->vPrefix) $tag[0] = $this->mPrefix;
 		}
 		return $tags;
 	}
@@ -383,7 +383,7 @@ class lessc {
 		// the operator for it to be a mathematical operator.
 
 		$needWhite = false;
-		if (!$this->inParens && preg_match('/\s/', $this->buffer{$this->count - 1})) {
+		if (!$this->inParens && preg_match('/\s/', $this->buffer[$this->count - 1])) {
 			$needWhite = true;
 		}
 
@@ -427,7 +427,7 @@ class lessc {
 			$ss = $this->seek();
 
 			$needWhite = false;
-			if (!$this->inParens && preg_match('/\s/', $this->buffer{$this->count - 1})) {
+			if (!$this->inParens && preg_match('/\s/', $this->buffer[$this->count - 1])) {
 				$needWhite = true;
 			}
 		}
@@ -470,7 +470,7 @@ class lessc {
 			$value = null;
 			if ($this->variable($var)) {
 				$value = array('variable', $var);
-			} elseif ($this->buffer{$this->count} == "(" && $this->expression($exp)) {
+			} elseif ($this->buffer[$this->count] == "(" && $this->expression($exp)) {
 				$value = $exp;
 			} else {
 				$this->seek($s);
@@ -904,7 +904,7 @@ class lessc {
 	function end() {
 		if ($this->literal(';'))
 			return true;
-		elseif ($this->count == strlen($this->buffer) || $this->buffer{$this->count} == '}') {
+		elseif ($this->count == strlen($this->buffer) || $this->buffer[$this->count] == '}') {
 			// if there is end of file or a closing block next then we don't need a ;
 			return true;
 		}
@@ -2146,7 +2146,7 @@ class lessc {
 
 		// shortcut on single letter
 		if (!$eatWhitespace && strlen($what) == 1) {
-			if ($this->buffer{$this->count} == $what) {
+			if ($this->buffer[$this->count] == $what) {
 				$this->count++;
 				return true;
 			}
@@ -2250,7 +2250,7 @@ class lessc {
 		$this->pushEnv();
 		$parser = new lessc();
 		foreach ($args as $name => $str_value) {
-			if ($name{0} != '@') $name = '@'.$name;
+			if ($name[0] != '@') $name = '@'.$name;
 			$parser->count = 0;
 			$parser->buffer = (string)$str_value;
 			if (!$parser->propertyValue($value)) {

--- a/engine/ICE/lib/markdown/markdown.php
+++ b/engine/ICE/lib/markdown/markdown.php
@@ -907,7 +907,7 @@ class Markdown_Parser {
 		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1]))
 			return $matches[0];
 		
-		$level = $matches[2]{0} == '=' ? 1 : 2;
+		$level = $matches[2][0] == '=' ? 1 : 2;
 		$block = "<h$level>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
@@ -1203,7 +1203,7 @@ class Markdown_Parser {
 				} else {
 					# Other closing marker: close one em or strong and
 					# change current token state to match the other
-					$token_stack[0] = str_repeat($token{0}, 3-$token_len);
+					$token_stack[0] = str_repeat($token[0], 3-$token_len);
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut($span);
@@ -1228,7 +1228,7 @@ class Markdown_Parser {
 				} else {
 					# Reached opening three-char emphasis marker. Push on token 
 					# stack; will be handled by the special condition above.
-					$em = $token{0};
+					$em = $token[0];
 					$strong = "$em$em";
 					array_unshift($token_stack, $token);
 					array_unshift($text_stack, '');
@@ -1557,9 +1557,9 @@ class Markdown_Parser {
 	# Handle $token provided by parseSpan by determining its nature and 
 	# returning the corresponding value that should replace it.
 	#
-		switch ($token{0}) {
+		switch ($token[0]) {
 			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
+				return $this->hashPart("&#". ord($token[1]). ";");
 			case "`":
 				# Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm', 


### PR DESCRIPTION
This causes a fatal error in PHP 8.x